### PR TITLE
Add feature "rename" to xsend dialog.

### DIFF
--- a/src/UI/Motif/xsend_file/Makefile.am
+++ b/src/UI/Motif/xsend_file/Makefile.am
@@ -25,6 +25,7 @@ AM_CPPFLAGS          = @AFD_MOTIF_INCLUDES@ -I../../.. -I../../common\
 bin_PROGRAMS         = xsend_file
 xsend_file_SOURCES   = callbacks.c\
                        create_url_file.c\
+                       rr_file_name_file.c\
                        send_file.c\
                        xsend_file.c
 xsend_file_LDADD     = ../common/libmotifafd.a\

--- a/src/UI/Motif/xsend_file/rr_file_name_file.c
+++ b/src/UI/Motif/xsend_file/rr_file_name_file.c
@@ -1,0 +1,229 @@
+/*
+ *  eval_files.c - Part of AFD, an automatic file distribution program.
+ *  Copyright (c) 2000 - 2012 Deutscher Wetterdienst (DWD),
+ *                            Holger Kiehl <Holger.Kiehl@dwd.de>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "afddefs.h"
+
+DESCR__S_M3
+/*
+ ** NAME
+ **   rr_file_name_file - modifies file with filenames
+ **
+ ** SYNOPSIS
+ **   void rr_file_name_file(char *file_name, struct data *p_db)
+ **
+ ** DESCRIPTION
+ **   This function applies the given rename-rule to all the filenames
+ **   in file_name_file, appending the target/remote name to the local name.
+ **   If there already is a rename-name, it is overwritten.
+ **   Afterwards the file_name_file is re-written with the changes.
+ **
+ ** RETURN VALUES
+ **   SUCCESS or INCORRECT.
+ **
+ ** AUTHOR
+ **   A.Maul
+ **
+ ** HISTORY
+ **   02.01.2019 A.Maul  Created.
+ */
+DESCR__E_M3
+
+#include <stdio.h>                 /* stderr, fprintf()                  */
+#include <stdlib.h>                /* atoi()                             */
+#include <string.h>                /* strcpy(), strerror(), strcmp()     */
+#include <unistd.h>                /* getpid(), write(), close()         */
+#include <fcntl.h>
+#include <errno.h>
+
+extern char file_name_file[], file_name_file_copy[];
+
+/*####################### _rr_file_name_file() #############################*/
+int rr_file_name_file(struct rule *rule, int rule_no, char *filter, char *rename_to)
+{
+   int ret;
+   char *buffer, *modbuf;
+   off_t buffer_sz, modbuf_sz;
+   struct stat foo;
+   int fd;
+
+   if (file_name_file_copy[0] == '\0')
+   {
+      (void) strcpy(file_name_file_copy, file_name_file);
+      (void) strcat(file_name_file_copy, ".rr");
+   }
+   if (stat(file_name_file_copy, &foo) != 0)
+   {
+      if ((buffer_sz = read_file_no_cr(file_name_file, &buffer, NO, __FILE__, __LINE__)) == INCORRECT)
+      {
+         ret = INCORRECT;
+      }
+      if ((fd = open(file_name_file_copy, (O_WRONLY | O_CREAT | O_TRUNC), (S_IRUSR | S_IWUSR))) == -1)
+      {
+         (void) fprintf(stderr, "Failed to open() `%s' : %s (%s %d)\n", file_name_file_copy, strerror(errno), __FILE__,
+               __LINE__);
+         return (INCORRECT);
+      }
+      else
+      {
+         if (write(fd, buffer, buffer_sz) != buffer_sz)
+         {
+            (void) fprintf(stderr, "Failed to write() to `%s' : %s (%s %d)\n", file_name_file_copy, strerror(errno),
+                  __FILE__, __LINE__);
+            return (INCORRECT);
+         }
+         if (close(fd) == -1)
+         {
+            (void) fprintf(stderr, "Failed to close() `%s' : %s (%s %d)\n", file_name_file_copy, strerror(errno),
+                  __FILE__, __LINE__);
+         }
+         ret = SUCCESS;
+      }
+   }
+   else
+   {
+      if ((buffer_sz = read_file_no_cr(file_name_file_copy, &buffer, NO, __FILE__, __LINE__)) == INCORRECT)
+      {
+         ret = INCORRECT;
+      }
+      ret = SUCCESS;
+   }
+   if (ret != INCORRECT)
+   {
+      char *ptr = buffer;
+      char *p_fn, filename[MAX_PATH_LENGTH], realname[MAX_PATH_LENGTH];
+      size_t length;
+      register int i, k;
+
+      modbuf_sz = 0;
+      modbuf = NULL;
+      length = 0;
+
+      do
+      {
+         i = 0;
+         while ((*ptr != '\n') && (*ptr != '|') && (*ptr != '\0'))
+         {
+            filename[i] = *ptr;
+            ptr++;
+            i++;
+         }
+         if (*ptr == '\n')
+         {
+            ptr++;
+         }
+         filename[i] = '\0';
+         if (*ptr == '|')
+         {
+            i = 0;
+            ptr++;
+            while ((*ptr != '\n') && (*ptr != '\0'))
+            {
+               realname[i] = *ptr;
+               ptr++;
+               i++;
+            }
+            if (*ptr == '\n')
+            {
+               ptr++;
+            }
+            realname[i] = '\0';
+            if (!(p_fn = strrchr(realname, '/')))
+            {
+               p_fn = realname;
+            }
+         }
+         else
+         {
+            realname[0] = '\0';
+            if (!(p_fn = strrchr(filename, '/')))
+            {
+               p_fn = filename;
+            }
+         }
+         if (*p_fn == '/')
+         {
+            p_fn++;
+         }
+         int counter_fd = -1, *unique_counter;
+         if (rule_no >= 0)
+         {
+            /* find and use rule from file rename.rule */
+            for (k = 0; k < rule[rule_no].no_of_rules; k++)
+            {
+               if (pmatch(rule[rule_no].filter[k], p_fn, NULL ) == 0)
+               {
+                  change_name(p_fn, rule[rule_no].filter[k], rule[rule_no].rename_to[k], realname, MAX_PATH_LENGTH,
+                        &counter_fd, &unique_counter, 0);
+                  break;
+               }
+            }
+         }
+         else
+            if ((filter != NULL )&& (rename_to != NULL) && (filter[0] != '\0') && (rename_to[0] != '\0')){
+            /* use single rename */
+            change_name(p_fn, filter, rename_to, realname, MAX_PATH_LENGTH,
+                  &counter_fd, &unique_counter, 0);
+         }
+         if ((length + strlen(filename) + strlen(realname) + 2) >= modbuf_sz)
+         {
+            modbuf_sz += 2 * MAX_PATH_LENGTH;
+            if (!(modbuf = (char*) realloc(modbuf, modbuf_sz * sizeof(char))))
+            {
+               (void) fprintf(stderr, "Could not realloc() memory : %s [%s %d]\n", strerror(errno), __FILE__, __LINE__);
+               return (INCORRECT);
+            }
+         }
+         if (realname[0])
+         {
+            length += sprintf(&modbuf[length], "%s|%s\n", filename, realname);
+         }
+         else
+         {
+            length += sprintf(&modbuf[length], "%s\n", filename);
+         }
+      } while ((*ptr != '\0') && (ptr < buffer + buffer_sz));
+
+      if ((fd = open(file_name_file, (O_WRONLY | O_CREAT | O_TRUNC), (S_IRUSR | S_IWUSR))) == -1)
+      {
+         (void) fprintf(stderr, "Failed to open() `%s' : %s (%s %d)\n", file_name_file, strerror(errno), __FILE__,
+               __LINE__);
+         return (INCORRECT);
+      }
+      else
+      {
+         if (write(fd, modbuf, length) != length)
+         {
+            (void) fprintf(stderr, "Failed to write() to `%s' : %s (%s %d)\n", file_name_file, strerror(errno),
+                  __FILE__, __LINE__);
+            return (INCORRECT);
+         }
+         if (close(fd) == -1)
+         {
+            (void) fprintf(stderr, "Failed to close() `%s' : %s (%s %d)\n", file_name_file, strerror(errno), __FILE__,
+                  __LINE__);
+         }
+      }
+      ret = SUCCESS;
+      free(buffer);
+      free(modbuf);
+   }
+
+   return (ret);
+}

--- a/src/UI/Motif/xsend_file/send_file.c
+++ b/src/UI/Motif/xsend_file/send_file.c
@@ -42,6 +42,7 @@ DESCR__S_M3
  ** HISTORY
  **   05.12.1999 H.Kiehl Created
  **   31.01.2005 H.Kiehl Adapted from xexec_cmd().
+ **   02.01.2019 A.Maul  Add parameter for LOCK_OFF to 'cmd'.
  **
  */
 DESCR__E_M3
@@ -148,6 +149,10 @@ send_file(void)
       {
          length += sprintf(&cmd[length], " -l DOT");
       }
+      else if (db->lock == SET_LOCK_OFF)
+           {
+              length += sprintf(&cmd[length], " -l OFF");
+           }
       else if (db->lock == SET_LOCK_DOT_VMS)
            {
               length += sprintf(&cmd[length], " -l DOT_VMS");

--- a/src/UI/Motif/xsend_file/xsend_file.h
+++ b/src/UI/Motif/xsend_file/xsend_file.h
@@ -48,6 +48,12 @@
 #define PREFIX_ENTER            33
 #define PROXY_NO_ENTER          34
 #define PROXY_ENTER             35
+#define RENAME_RULE_NO_ENTER    36
+#define RENAME_RULE_ENTER       37
+#define RENAME_FILT_NO_ENTER    38
+#define RENAME_FILT_ENTER       39
+#define RENAME_PATT_NO_ENTER    40
+#define RENAME_PATT_ENTER       41
 
 #define CREATE_DIR_TOGGLE       0
 #define ATTACH_FILE_TOGGLE      1
@@ -121,6 +127,10 @@
                          (XtPointer)PASSWORD_ENTER);                   \
         }
 
+#define SET_RENAME_ON           1
+#define SET_RENAME_RULE         2
+#define SET_RENAME_MANUAL       4
+
 /* Structure holding all data of for sending files. */
 struct send_data
        {
@@ -137,6 +147,10 @@ struct send_data
           XT_PTR_TYPE lock;           /* DOT, DOT_VMS, OFF, etc.     */
           XT_PTR_TYPE transfer_mode;
           XT_PTR_TYPE protocol;
+          XT_PTR_TYPE rename_do;
+          int         rename_num;
+          char        rename_filt[MAX_FILENAME_LENGTH];
+          char        rename_patt[MAX_FILENAME_LENGTH];
           int         port;
           int         debug;
           time_t      timeout;
@@ -156,6 +170,77 @@ extern void close_button(Widget, XtPointer, XtPointer),
             protocol_toggled(Widget, XtPointer, XtPointer),
             send_button(Widget, XtPointer, XtPointer),
             send_file(void),
-            send_save_input(Widget, XtPointer, XtPointer);
+            send_save_input(Widget, XtPointer, XtPointer),
+            rename_onoff(Widget, XtPointer, XtPointer),
+            rename_toggle(Widget, XtPointer, XtPointer),
+            rename_eval(Widget, XtPointer, XtPointer);
+extern int  rr_file_name_file(struct rule*, int, char*, char*);
+
+#define _set_rename_boxies(what) if ((what) == OFF)\
+   {\
+      if ((db->protocol != FTP)\
+            && (db->protocol != LOC))\
+      {\
+         XtSetSensitive(rename_label_w[0], False);\
+         XtSetSensitive(rename_onoff_w, False);\
+      }\
+      XtSetSensitive(rename_toggle_w, False);\
+      if (rename_label_w[3])\
+      {\
+         XtSetSensitive(rename_label_w[3], False);\
+      }\
+      XtSetSensitive(rename_menu_w, False);\
+      XtSetSensitive(rename_label_w[1], False);\
+      XtSetSensitive(rename_label_w[2], False);\
+      XtSetSensitive(rename_filt_w, False);\
+      XtSetSensitive(rename_patt_w, False);\
+   }\
+   else\
+   {\
+      XtSetSensitive(rename_label_w[0], True);\
+      XtSetSensitive(rename_onoff_w, True);\
+      if (db->rename_do & SET_RENAME_ON)\
+      {\
+         XtSetSensitive(rename_toggle_w, True);\
+         if (db->rename_do & SET_RENAME_MANUAL)\
+         {\
+            if (rename_label_w[3])\
+            {\
+               XtSetSensitive(rename_label_w[3], False);\
+            }\
+            XtSetSensitive(rename_menu_w, False);\
+            XtSetSensitive(rename_label_w[1], True);\
+            XtSetSensitive(rename_label_w[2], True);\
+            XtSetSensitive(rename_filt_w, True);\
+            XtSetSensitive(rename_patt_w, True);\
+         }\
+         else\
+         {\
+            if (rename_label_w[3])\
+            {\
+               XtSetSensitive(rename_label_w[3], True);\
+            }\
+            XtSetSensitive(rename_menu_w, True);\
+            XtSetSensitive(rename_label_w[1], False);\
+            XtSetSensitive(rename_label_w[2], False);\
+            XtSetSensitive(rename_filt_w, False);\
+            XtSetSensitive(rename_patt_w, False);\
+         }\
+      }\
+      else\
+      {\
+         XtSetSensitive(rename_toggle_w, False);\
+         if (rename_label_w[3])\
+         {\
+            XtSetSensitive(rename_label_w[3], False);\
+         }\
+         XtSetSensitive(rename_menu_w, False);\
+         XtSetSensitive(rename_label_w[1], False);\
+         XtSetSensitive(rename_label_w[2], False);\
+         XtSetSensitive(rename_filt_w, False);\
+         XtSetSensitive(rename_patt_w, False);\
+      }\
+   }\
+/* END define _set_rename_boxies */
 
 #endif /* __xsend_file_h */


### PR DESCRIPTION
In xsend (called from show_olog->[Send]) the files to send can be
renamed by
1) selecting a rename-rule or
2) manualy setting a filter/pattern pair.