### PR TITLE
Fix transfer rate limit documentation

### DIFF
--- a/doc/html-en/host_config.html
+++ b/doc/html-en/host_config.html
@@ -412,7 +412,7 @@ host. See below for a description of each entry.
 </tr>
 <tr>
    <th valign=top><a name="transfer_rate_limit">Transfer rate limit</a></th>
-   <td>The maximum number of kilobytes that may be transferred per second.
+   <td>The maximum number of bytes that may be transferred per second.
        This option does nothing for the scheme file.</td>
 </tr>
 <tr>


### PR DESCRIPTION
From our observations and according to `src/init_afd/afddefs.h:2787`, the unit of the transfer rate limit is bytes per second, not kilobytes.