### PR TITLE
Update INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,6 @@
 
+0.) If you do not have a configure file you can create it by running the
+    script ac-tools/bootstrap. This script needs autoconfig and automake.
 
 1.) Run   ./configure   to generate config.h and the various Makefiles.
     ./configure --help   gives a list of possible options with slightly


### PR DESCRIPTION
Changes:
- Added information about how to generate ./configure

---
It may be beneficial to add information about how to generate the `./configure` script directly into the `INSTALL` file in the root directory as it currently only states to run the not included `./configure` script directly.

E.g. copied out of the HTML docs:
```text
0.) If you do not have a configure file you can create it by running the
    script ac-tools/bootstrap. This script needs autoconfig and automake.
```